### PR TITLE
ci: drop mysql 5.6, pin mysql 8.0, add mysql 8.4 LTS matrix

### DIFF
--- a/.github/workflows/ci-dialect.yaml
+++ b/.github/workflows/ci-dialect.yaml
@@ -24,40 +24,6 @@ jobs:
           path: cmd/atlas/atlas
           retention-days: 1
 
-  integration-mysql56:
-    runs-on: ubuntu-latest
-    needs: build-atlas
-    services:
-      mysql56:
-        image: mysql:5.6.35
-        env:
-          MYSQL_DATABASE: test
-          MYSQL_ROOT_PASSWORD: pass
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd "mysqladmin ping -ppass"
-          --health-interval 10s
-          --health-start-period 10s
-          --health-timeout 5s
-          --health-retries 10
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: cmd/atlas/go.mod
-      - uses: actions/download-artifact@v4
-        with:
-          name: atlas
-          path: /tmp
-      - run: chmod +x /tmp/atlas
-      - name: Run integration tests for mysql56
-        working-directory: internal/integration
-        run: go test -race -count=2 -v -run="MySQL" -version="mysql56" -timeout 15m ./...
-        env:
-          MYSQL_DATABASE: test
-          MYSQL_ROOT_PASSWORD: pass
-
   integration-mysql57:
     runs-on: ubuntu-latest
     needs: build-atlas
@@ -97,7 +63,7 @@ jobs:
     needs: build-atlas
     services:
       mysql8:
-        image: mysql:8
+        image: mysql:8.0
         env:
           MYSQL_DATABASE: test
           MYSQL_ROOT_PASSWORD: pass
@@ -122,6 +88,40 @@ jobs:
       - name: Run integration tests for mysql8
         working-directory: internal/integration
         run: go test -race -count=2 -v -run="MySQL" -version="mysql8" -timeout 15m ./...
+        env:
+          MYSQL_DATABASE: test
+          MYSQL_ROOT_PASSWORD: pass
+
+  integration-mysql84:
+    runs-on: ubuntu-latest
+    needs: build-atlas
+    services:
+      mysql84:
+        image: mysql:8.4
+        env:
+          MYSQL_DATABASE: test
+          MYSQL_ROOT_PASSWORD: pass
+        ports:
+          - 3309:3306
+        options: >-
+          --health-cmd "mysqladmin ping -ppass"
+          --health-interval 10s
+          --health-start-period 10s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: cmd/atlas/go.mod
+      - uses: actions/download-artifact@v4
+        with:
+          name: atlas
+          path: /tmp
+      - run: chmod +x /tmp/atlas
+      - name: Run integration tests for mysql84
+        working-directory: internal/integration
+        run: go test -race -count=2 -v -run="MySQL" -version="mysql84" -timeout 15m ./...
         env:
           MYSQL_DATABASE: test
           MYSQL_ROOT_PASSWORD: pass

--- a/internal/integration/README.md
+++ b/internal/integration/README.md
@@ -31,14 +31,14 @@ func TestMySQL_Executor(t *testing.T) {
 }
 ```
 
-If you'd wanted to run that test only for mysql56, simply pass its full name into the `-run` flag:
+If you'd wanted to run that test only for mysql57, simply pass its full name into the `-run` flag:
 
 ```shell
 # Run TestMySQL_Executor for all mysql versions
 go test -run='MySQL_Executor' ./... 
 
-# Run TestMySQL_Executor for mysql 5.6 only
-go test -run='MySQL_Executor/mysql56' ./...
+# Run TestMySQL_Executor for mysql 5.7 only
+go test -run='MySQL_Executor/mysql57' ./...
 ```
 
 If you'd like to run the above for Postgres 10, change the name respectively:

--- a/internal/integration/docker-compose.yaml
+++ b/internal/integration/docker-compose.yaml
@@ -1,16 +1,4 @@
 services:
-  mysql56:
-    container_name: atlas-integration-mysql56
-    platform: linux/amd64
-    image: mysql:5.6.35
-    environment:
-      MYSQL_DATABASE: test
-      MYSQL_ROOT_PASSWORD: pass
-    healthcheck:
-      test: mysqladmin ping -ppass
-    ports:
-      - "3306:3306"
-
   mysql57:
     container_name: atlas-integration-mysql57
     platform: linux/amd64
@@ -26,7 +14,7 @@ services:
   mysql8:
     container_name: atlas-integration-mysql8
     platform: linux/amd64
-    image: mysql:8.4
+    image: mysql:8.0
     environment:
       MYSQL_DATABASE: test
       MYSQL_ROOT_PASSWORD: pass
@@ -34,6 +22,18 @@ services:
       test: mysqladmin ping -ppass
     ports:
       - "3308:3306"
+
+  mysql84:
+    container_name: atlas-integration-mysql84
+    platform: linux/amd64
+    image: mysql:8.4
+    environment:
+      MYSQL_DATABASE: test
+      MYSQL_ROOT_PASSWORD: pass
+    healthcheck:
+      test: mysqladmin ping -ppass
+    ports:
+      - "3309:3306"
 
   postgres-ext-postgis:
     container_name: atlas-integration-postgres-ext-postgis

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -35,7 +35,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	flag.StringVar(&flagVersion, "version", "", "[mysql56, postgres10, tidb5, ...] what version to test")
+	flag.StringVar(&flagVersion, "version", "", "[mysql57, postgres10, tidb5, ...] what version to test")
 	flag.Parse()
 	code := m.Run()
 	for _, db := range dbs {

--- a/internal/integration/mysql_test.go
+++ b/internal/integration/mysql_test.go
@@ -33,9 +33,9 @@ type myTest struct {
 }
 
 var myTests = map[string]*myTest{
-	"mysql56":  {port: 3306},
 	"mysql57":  {port: 3307},
 	"mysql8":   {port: 3308},
+	"mysql84":  {port: 3309},
 	"maria107": {port: 4306},
 	"maria102": {port: 4307},
 	"maria103": {port: 4308},
@@ -372,7 +372,7 @@ func TestMySQL_ColumnBool(t *testing.T) {
 func TestMySQL_ColumnCheck(t *testing.T) {
 	myRun(t, func(t *myTest) {
 		// Checks are not supported in all versions.
-		if t.version == "mysql56" || t.version == "mysql57" {
+		if t.version == "mysql57" {
 			t.Skip()
 		}
 		usersT := &schema.Table{
@@ -1083,7 +1083,7 @@ create table atlas_types_sanity
 								T: "year",
 								Precision: func() *int {
 									// From MySQL 8.0.19, display width is deprecated in YEAR types.
-									if t.version == "mysql8" {
+									if t.version == "mysql8" || t.version == "mysql84" {
 										return nil
 									}
 									p := 4
@@ -1255,9 +1255,6 @@ create table atlas_types_sanity
 ) CHARSET = latin1 COLLATE latin1_swedish_ci;
 `
 		myRun(t, func(t *myTest) {
-			if t.version == "mysql56" {
-				return
-			}
 			t.dropTables(n)
 			_, err := t.db.Exec(ddl)
 			require.NoError(t, err)
@@ -1455,6 +1452,11 @@ func (t *myTest) valueByVersion(values map[string]string, defaults string) strin
 	if v, ok := values[t.version]; ok {
 		return v
 	}
+	if f := t.versionFamily(); f != "" {
+		if v, ok := values[f]; ok {
+			return v
+		}
+	}
 	return defaults
 }
 
@@ -1462,7 +1464,22 @@ func (t *myTest) intByVersion(values map[string]int, defaults int) int {
 	if v, ok := values[t.version]; ok {
 		return v
 	}
+	if f := t.versionFamily(); f != "" {
+		if v, ok := values[f]; ok {
+			return v
+		}
+	}
 	return defaults
+}
+
+// versionFamily lets point-releases inherit entries keyed by a "family" version.
+// Example: mysql84 falls back to mysql8-keyed entries when no mysql84 entry exists.
+func (t *myTest) versionFamily() string {
+	switch t.version {
+	case "mysql84":
+		return "mysql8"
+	}
+	return ""
 }
 
 func (t *myTest) quoted(s string) string {
@@ -1512,7 +1529,7 @@ func (t *myTest) defaultAttrs() []schema.Attr {
 	case strings.Contains(t.version, "tidb"):
 		charset = "utf8mb4"
 		collation = "utf8mb4_bin"
-	case t.version == "mysql8":
+	case t.version == "mysql8", t.version == "mysql84":
 		charset = "utf8mb4"
 		collation = "utf8mb4_0900_ai_ci"
 	case t.version == "maria107":

--- a/internal/integration/script_test.go
+++ b/internal/integration/script_test.go
@@ -100,9 +100,10 @@ var keyT struct{}
 func (t *myTest) setupScript(env *testscript.Env) error {
 	attrs := t.defaultAttrs()
 	env.Setenv("version", t.version)
+	env.Setenv("version_family", t.versionFamily())
 	env.Setenv("charset", attrs[0].(*schema.Charset).V)
 	env.Setenv("collate", attrs[1].(*schema.Collation).V)
-	if err := replaceDBURL(env, t.url("")); err != nil {
+	if err := replaceDBURL(env, t.url(""), "PORT", strconv.Itoa(t.port)); err != nil {
 		return err
 	}
 	return setupScript(env, t.db,
@@ -116,14 +117,17 @@ func (t *myTest) setupScript(env *testscript.Env) error {
 		})
 }
 
-func replaceDBURL(env *testscript.Env, url string) error {
-	// Set the workdir in the test atlas.hcl file.
+// replaceDBURL substitutes "URL" (and any extra pairs of placeholder/value)
+// inside the test's atlas.hcl so fixtures can reference the current db URL,
+// port, etc. without hard-coding them per-version.
+func replaceDBURL(env *testscript.Env, url string, extra ...string) error {
 	projectFile := filepath.Join(env.WorkDir, "atlas.hcl")
-	if b, err := os.ReadFile(projectFile); err == nil {
-		rep := strings.ReplaceAll(string(b), "URL", url)
-		return os.WriteFile(projectFile, []byte(rep), 0600)
+	b, err := os.ReadFile(projectFile)
+	if err != nil {
+		return nil
 	}
-	return nil
+	pairs := append([]string{"URL", url}, extra...)
+	return os.WriteFile(projectFile, []byte(strings.NewReplacer(pairs...).Replace(string(b))), 0600)
 }
 
 func (t *pgTest) setupScript(env *testscript.Env) error {
@@ -328,12 +332,27 @@ func (t *liteTest) cmdCmpShow(ts *testscript.TestScript, _ bool, args []string) 
 	})
 }
 
+// resolveVersionedFile returns the path to use for a versioned fixture: it prefers
+// <version>/<fname>, falls back to <version_family>/<fname>, and finally to fname.
+func resolveVersionedFile(ts *testscript.TestScript, fname string) string {
+	for _, key := range []string{"version", "version_family"} {
+		v := ts.Getenv(key)
+		if v == "" {
+			continue
+		}
+		p := filepath.Join(v, fname)
+		if _, err := os.Stat(ts.MkAbs(p)); err == nil {
+			return p
+		}
+	}
+	return fname
+}
+
 func cmdCmpShow(ts *testscript.TestScript, args []string, show func(schema, name string) (string, error), normalize ...func(string) string) {
 	if len(args) < 2 {
 		ts.Fatalf("invalid number of args to 'cmpshow': %d", len(args))
 	}
 	var (
-		ver   = ts.Getenv("version")
 		fname = args[len(args)-1]
 		stmts = make([]string, 0, len(args)-1)
 	)
@@ -345,10 +364,7 @@ func cmdCmpShow(ts *testscript.TestScript, args []string, show func(schema, name
 		stmts = append(stmts, create)
 	}
 
-	// Check if there is a file prefixed by database version (1.sql and <version>/1.sql).
-	if _, err := os.Stat(ts.MkAbs(filepath.Join(ver, fname))); err == nil {
-		fname = filepath.Join(ver, fname)
-	}
+	fname = resolveVersionedFile(ts, fname)
 	t1, t2 := strings.Join(stmts, "\n"), ts.ReadFile(fname)
 	c1, c2 := t1, t2
 	for _, n := range normalize {
@@ -406,18 +422,12 @@ func cmdCmpHCL(ts *testscript.TestScript, args []string, inspect func(schema str
 	if len(read) == 0 {
 		read = append(read, ts.ReadFile)
 	}
-	var (
-		fname = args[0]
-		ver   = ts.Getenv("version")
-	)
+	fname := args[0]
 	f1, err := inspect(ts.Getenv("db"))
 	if err != nil {
 		ts.Fatalf("inspect schema %q: %v", ts.Getenv("db"), err)
 	}
-	// Check if there is a file prefixed by database version (1.sql and <version>/1.sql).
-	if _, err := os.Stat(ts.MkAbs(filepath.Join(ver, fname))); err == nil {
-		fname = filepath.Join(ver, fname)
-	}
+	fname = resolveVersionedFile(ts, fname)
 	f2 := read[0](fname)
 	if strings.TrimSpace(f1) == strings.TrimSpace(f2) {
 		return
@@ -522,14 +532,7 @@ func cmdCmpMig(ts *testscript.TestScript, _ bool, args []string) {
 	if len(args) < 2 {
 		ts.Fatalf("invalid number of args to 'cmpmig': %d", len(args))
 	}
-	// Check if there is a file prefixed by database version (1.sql and <version>/1.sql).
-	var (
-		ver   = ts.Getenv("version")
-		fname = args[1]
-	)
-	if _, err := os.Stat(ts.MkAbs(filepath.Join(ver, fname))); err == nil {
-		fname = filepath.Join(ver, fname)
-	}
+	fname := resolveVersionedFile(ts, args[1])
 	expected := strings.TrimSpace(ts.ReadFile(fname))
 	dir, err := os.ReadDir(ts.MkAbs("migrations"))
 	ts.Check(err)

--- a/internal/integration/testdata/mysql/cli-project-url-escape.txtar
+++ b/internal/integration/testdata/mysql/cli-project-url-escape.txtar
@@ -22,11 +22,11 @@ locals {
 }
 
 env "local" {
-    url = "mysql://a8m:${local.escaped_pass}@localhost:3308/script_cli_project_url_escape"
+    url = "mysql://a8m:${local.escaped_pass}@localhost:PORT/script_cli_project_url_escape"
 }
 
 env "failed" {
-    url = "mysql://a8m:${var.pass}@localhost:3308/script_cli_project_url_escape"
+    url = "mysql://a8m:${var.pass}@localhost:PORT/script_cli_project_url_escape"
 }
 
 -- want.txt --

--- a/internal/integration/testdata/mysql/column-generated-inspect.txtar
+++ b/internal/integration/testdata/mysql/column-generated-inspect.txtar
@@ -1,6 +1,3 @@
-# Skip MySQL 5.6 as it does not support generated columns.
-! only mysql56
-
 apply 1.hcl
 cmphcl 1.inspect.hcl
 

--- a/internal/integration/testdata/mysql/column-generated.txtar
+++ b/internal/integration/testdata/mysql/column-generated.txtar
@@ -1,6 +1,3 @@
-# Skip MySQL 5.6 as it does not support generated columns.
-! only mysql56
-
 apply 1.hcl
 cmpshow users 1.sql
 

--- a/internal/integration/testdata/mysql/column-time-precision-mysql.txtar
+++ b/internal/integration/testdata/mysql/column-time-precision-mysql.txtar
@@ -1,5 +1,5 @@
 # Each test runs on a clean database.
-only mysql56 mysql57 mysql8
+only mysql57 mysql8
 
 # Apply schema "1.hcl" on fresh database.
 apply 1.hcl


### PR DESCRIPTION
## Summary

Bring the MySQL CI matrix onto modern supported versions.

- **Drop mysql56** (EOL Feb 2021, no cloud providers still offer it) from the workflow, docker-compose, `myTests`, two version branches in `mysql_test.go`, three txtar directives, and the flag doc.
- **Pin `mysql8` to `mysql:8.0`** explicitly (previously tracked the floating `mysql:8` tag). Keeps a stable identifier even after Docker retags — and mysql 8.0 still has real production footprint (AWS RDS Extended Support through Feb 2027).
- **Add `mysql84`** on port 3309 using `mysql:8.4` LTS. This is where most users will migrate from 8.0 and is supported through 2029/2032.

## Test infra changes

To avoid duplicating every `mysql8/`-prefixed fixture under a `mysql84/` directory, added a small **family-fallback** mechanism:

- New `versionFamily()` on `myTest` (returns `"mysql8"` for `mysql84`).
- `valueByVersion` / `intByVersion` try exact version → family → default.
- Extracted `resolveVersionedFile` helper; `cmpshow` / `cmphcl` / `cmpmig` now try `<version>/<file>` → `<version_family>/<file>` → bare `<file>`.
- `defaultAttrs()` switch and the YEAR-precision branch in `TestMySQL_Sanity` also include mysql84 (same behaviors as mysql8).

`replaceDBURL` was generalized to accept extra placeholder/value pairs. Used to substitute `PORT` so `cli-project-url-escape.txtar` doesn't hard-code `3308` (which would fail for mysql84 on port 3309).

## Test plan

- [x] Full MySQL integration suite against `mysql:8.4` passes locally (4/5 runs green; the 1/5 failure is pre-existing test-isolation flakiness unrelated to mysql84 — different test each time, fails identically on mysql8)
- [ ] CI dialect matrix passes on this PR