### PR TITLE
Add binary coverage collection to dialect integration jobs

### DIFF
--- a/.github/workflows/ci-dialect.yaml
+++ b/.github/workflows/ci-dialect.yaml
@@ -7,6 +7,7 @@ concurrency:
 env:
   ATLAS_NO_UPGRADE_SUGGESTIONS: 1
   ATLAS_TEST_BINARY: /tmp/atlas
+  GOCOVERDIR: /tmp/gocover
 jobs:
   build-atlas:
     runs-on: ubuntu-latest
@@ -15,9 +16,9 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: cmd/atlas/go.mod
-      - name: Build atlas CLI
+      - name: Build atlas CLI with coverage instrumentation
         working-directory: cmd/atlas
-        run: go build -o atlas .
+        run: go build -cover -coverpkg=ariga.io/atlas/... -o atlas .
       - uses: actions/upload-artifact@v4
         with:
           name: atlas
@@ -55,16 +56,30 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: Run integration tests for mysql57
         working-directory: internal/integration
-        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="MySQL" -version="mysql57" -timeout 15m ./...
+        run: |
+          mkdir -p "$GOCOVERDIR"
+          gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="MySQL" -version="mysql57" -timeout 15m ./...
         env:
           MYSQL_DATABASE: test
           MYSQL_ROOT_PASSWORD: pass
+      - name: Convert binary coverage
+        if: ${{ !cancelled() }}
+        working-directory: internal/integration
+        run: go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage.txt
+      - name: Upload coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: internal/integration/coverage.txt
+          flags: integration-mysql57
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: internal/integration/junit.xml
+          report_type: test_results
 
   integration-mysql8:
     runs-on: ubuntu-latest
@@ -97,16 +112,30 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: Run integration tests for mysql8
         working-directory: internal/integration
-        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="MySQL" -version="mysql8" -timeout 15m ./...
+        run: |
+          mkdir -p "$GOCOVERDIR"
+          gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="MySQL" -version="mysql8" -timeout 15m ./...
         env:
           MYSQL_DATABASE: test
           MYSQL_ROOT_PASSWORD: pass
+      - name: Convert binary coverage
+        if: ${{ !cancelled() }}
+        working-directory: internal/integration
+        run: go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage.txt
+      - name: Upload coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: internal/integration/coverage.txt
+          flags: integration-mysql8
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: internal/integration/junit.xml
+          report_type: test_results
 
   integration-mysql84:
     runs-on: ubuntu-latest
@@ -139,16 +168,30 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: Run integration tests for mysql84
         working-directory: internal/integration
-        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="MySQL" -version="mysql84" -timeout 15m ./...
+        run: |
+          mkdir -p "$GOCOVERDIR"
+          gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="MySQL" -version="mysql84" -timeout 15m ./...
         env:
           MYSQL_DATABASE: test
           MYSQL_ROOT_PASSWORD: pass
+      - name: Convert binary coverage
+        if: ${{ !cancelled() }}
+        working-directory: internal/integration
+        run: go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage.txt
+      - name: Upload coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: internal/integration/coverage.txt
+          flags: integration-mysql84
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: internal/integration/junit.xml
+          report_type: test_results
 
   integration-maria107:
     runs-on: ubuntu-latest
@@ -181,16 +224,30 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: Run integration tests for maria107
         working-directory: internal/integration
-        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="MySQL" -version="maria107" -timeout 15m ./...
+        run: |
+          mkdir -p "$GOCOVERDIR"
+          gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="MySQL" -version="maria107" -timeout 15m ./...
         env:
           MYSQL_DATABASE: test
           MYSQL_ROOT_PASSWORD: pass
+      - name: Convert binary coverage
+        if: ${{ !cancelled() }}
+        working-directory: internal/integration
+        run: go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage.txt
+      - name: Upload coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: internal/integration/coverage.txt
+          flags: integration-maria107
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: internal/integration/junit.xml
+          report_type: test_results
 
   integration-maria102:
     runs-on: ubuntu-latest
@@ -223,16 +280,30 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: Run integration tests for maria102
         working-directory: internal/integration
-        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="MySQL" -version="maria102" -timeout 15m ./...
+        run: |
+          mkdir -p "$GOCOVERDIR"
+          gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="MySQL" -version="maria102" -timeout 15m ./...
         env:
           MYSQL_DATABASE: test
           MYSQL_ROOT_PASSWORD: pass
+      - name: Convert binary coverage
+        if: ${{ !cancelled() }}
+        working-directory: internal/integration
+        run: go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage.txt
+      - name: Upload coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: internal/integration/coverage.txt
+          flags: integration-maria102
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: internal/integration/junit.xml
+          report_type: test_results
 
   integration-maria103:
     runs-on: ubuntu-latest
@@ -265,16 +336,30 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: Run integration tests for maria103
         working-directory: internal/integration
-        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="MySQL" -version="maria103" -timeout 15m ./...
+        run: |
+          mkdir -p "$GOCOVERDIR"
+          gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="MySQL" -version="maria103" -timeout 15m ./...
         env:
           MYSQL_DATABASE: test
           MYSQL_ROOT_PASSWORD: pass
+      - name: Convert binary coverage
+        if: ${{ !cancelled() }}
+        working-directory: internal/integration
+        run: go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage.txt
+      - name: Upload coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: internal/integration/coverage.txt
+          flags: integration-maria103
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: internal/integration/junit.xml
+          report_type: test_results
 
   integration-postgres-ext-postgis:
     runs-on: ubuntu-latest
@@ -306,16 +391,30 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: Run integration tests for postgres-ext-postgis
         working-directory: internal/integration
-        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="Postgres" -version="postgres-ext-postgis" -timeout 15m ./...
+        run: |
+          mkdir -p "$GOCOVERDIR"
+          gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="Postgres" -version="postgres-ext-postgis" -timeout 15m ./...
         env:
           POSTGRES_DB: test
           POSTGRES_PASSWORD: pass
+      - name: Convert binary coverage
+        if: ${{ !cancelled() }}
+        working-directory: internal/integration
+        run: go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage.txt
+      - name: Upload coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: internal/integration/coverage.txt
+          flags: integration-postgres-ext-postgis
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: internal/integration/junit.xml
+          report_type: test_results
 
   integration-postgres12:
     runs-on: ubuntu-latest
@@ -347,16 +446,30 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: Run integration tests for postgres12
         working-directory: internal/integration
-        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="Postgres" -version="postgres12" -timeout 15m ./...
+        run: |
+          mkdir -p "$GOCOVERDIR"
+          gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="Postgres" -version="postgres12" -timeout 15m ./...
         env:
           POSTGRES_DB: test
           POSTGRES_PASSWORD: pass
+      - name: Convert binary coverage
+        if: ${{ !cancelled() }}
+        working-directory: internal/integration
+        run: go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage.txt
+      - name: Upload coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: internal/integration/coverage.txt
+          flags: integration-postgres12
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: internal/integration/junit.xml
+          report_type: test_results
 
   integration-postgres13:
     runs-on: ubuntu-latest
@@ -388,16 +501,30 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: Run integration tests for postgres13
         working-directory: internal/integration
-        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="Postgres" -version="postgres13" -timeout 15m ./...
+        run: |
+          mkdir -p "$GOCOVERDIR"
+          gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="Postgres" -version="postgres13" -timeout 15m ./...
         env:
           POSTGRES_DB: test
           POSTGRES_PASSWORD: pass
+      - name: Convert binary coverage
+        if: ${{ !cancelled() }}
+        working-directory: internal/integration
+        run: go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage.txt
+      - name: Upload coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: internal/integration/coverage.txt
+          flags: integration-postgres13
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: internal/integration/junit.xml
+          report_type: test_results
 
   integration-postgres14:
     runs-on: ubuntu-latest
@@ -429,16 +556,30 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: Run integration tests for postgres14
         working-directory: internal/integration
-        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="Postgres" -version="postgres14" -timeout 15m ./...
+        run: |
+          mkdir -p "$GOCOVERDIR"
+          gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="Postgres" -version="postgres14" -timeout 15m ./...
         env:
           POSTGRES_DB: test
           POSTGRES_PASSWORD: pass
+      - name: Convert binary coverage
+        if: ${{ !cancelled() }}
+        working-directory: internal/integration
+        run: go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage.txt
+      - name: Upload coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: internal/integration/coverage.txt
+          flags: integration-postgres14
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: internal/integration/junit.xml
+          report_type: test_results
 
   integration-postgres15:
     runs-on: ubuntu-latest
@@ -470,16 +611,30 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: Run integration tests for postgres15
         working-directory: internal/integration
-        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="Postgres" -version="postgres15" -timeout 15m ./...
+        run: |
+          mkdir -p "$GOCOVERDIR"
+          gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="Postgres" -version="postgres15" -timeout 15m ./...
         env:
           POSTGRES_DB: test
           POSTGRES_PASSWORD: pass
+      - name: Convert binary coverage
+        if: ${{ !cancelled() }}
+        working-directory: internal/integration
+        run: go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage.txt
+      - name: Upload coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: internal/integration/coverage.txt
+          flags: integration-postgres15
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: internal/integration/junit.xml
+          report_type: test_results
 
   integration-postgres16:
     runs-on: ubuntu-latest
@@ -511,16 +666,30 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: Run integration tests for postgres16
         working-directory: internal/integration
-        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="Postgres" -version="postgres16" -timeout 15m ./...
+        run: |
+          mkdir -p "$GOCOVERDIR"
+          gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="Postgres" -version="postgres16" -timeout 15m ./...
         env:
           POSTGRES_DB: test
           POSTGRES_PASSWORD: pass
+      - name: Convert binary coverage
+        if: ${{ !cancelled() }}
+        working-directory: internal/integration
+        run: go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage.txt
+      - name: Upload coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: internal/integration/coverage.txt
+          flags: integration-postgres16
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: internal/integration/junit.xml
+          report_type: test_results
 
   integration-postgres17:
     runs-on: ubuntu-latest
@@ -552,16 +721,30 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: Run integration tests for postgres17
         working-directory: internal/integration
-        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="Postgres" -version="postgres17" -timeout 15m ./...
+        run: |
+          mkdir -p "$GOCOVERDIR"
+          gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="Postgres" -version="postgres17" -timeout 15m ./...
         env:
           POSTGRES_DB: test
           POSTGRES_PASSWORD: pass
+      - name: Convert binary coverage
+        if: ${{ !cancelled() }}
+        working-directory: internal/integration
+        run: go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage.txt
+      - name: Upload coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: internal/integration/coverage.txt
+          flags: integration-postgres17
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: internal/integration/junit.xml
+          report_type: test_results
 
   integration-postgres18:
     runs-on: ubuntu-latest
@@ -593,16 +776,30 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: Run integration tests for postgres18
         working-directory: internal/integration
-        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="Postgres" -version="postgres18" -timeout 15m ./...
+        run: |
+          mkdir -p "$GOCOVERDIR"
+          gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="Postgres" -version="postgres18" -timeout 15m ./...
         env:
           POSTGRES_DB: test
           POSTGRES_PASSWORD: pass
+      - name: Convert binary coverage
+        if: ${{ !cancelled() }}
+        working-directory: internal/integration
+        run: go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage.txt
+      - name: Upload coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: internal/integration/coverage.txt
+          flags: integration-postgres18
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: internal/integration/junit.xml
+          report_type: test_results
 
   integration-sqlite:
     runs-on: ubuntu-latest
@@ -621,13 +818,27 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: Run integration tests for sqlite
         working-directory: internal/integration
-        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="SQLite.*" -version="sqlite" -timeout 15m ./...
+        run: |
+          mkdir -p "$GOCOVERDIR"
+          gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="SQLite.*" -version="sqlite" -timeout 15m ./...
+      - name: Convert binary coverage
+        if: ${{ !cancelled() }}
+        working-directory: internal/integration
+        run: go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage.txt
+      - name: Upload coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: internal/integration/coverage.txt
+          flags: integration-sqlite
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: internal/integration/junit.xml
+          report_type: test_results
 
   integration-tidb5:
     runs-on: ubuntu-latest
@@ -651,13 +862,27 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: Run integration tests for tidb5
         working-directory: internal/integration
-        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="TiDB" -version="tidb5" -timeout 15m ./...
+        run: |
+          mkdir -p "$GOCOVERDIR"
+          gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="TiDB" -version="tidb5" -timeout 15m ./...
+      - name: Convert binary coverage
+        if: ${{ !cancelled() }}
+        working-directory: internal/integration
+        run: go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage.txt
+      - name: Upload coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: internal/integration/coverage.txt
+          flags: integration-tidb5
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: internal/integration/junit.xml
+          report_type: test_results
 
   integration-tidb6:
     runs-on: ubuntu-latest
@@ -681,13 +906,27 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: Run integration tests for tidb6
         working-directory: internal/integration
-        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="TiDB" -version="tidb6" -timeout 15m ./...
+        run: |
+          mkdir -p "$GOCOVERDIR"
+          gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -run="TiDB" -version="tidb6" -timeout 15m ./...
+      - name: Convert binary coverage
+        if: ${{ !cancelled() }}
+        working-directory: internal/integration
+        run: go tool covdata textfmt -i="$GOCOVERDIR" -o=coverage.txt
+      - name: Upload coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: internal/integration/coverage.txt
+          flags: integration-tidb6
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: internal/integration/junit.xml
+          report_type: test_results
 
   ci-passed:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-dialect.yaml
+++ b/.github/workflows/ci-dialect.yaml
@@ -1,6 +1,9 @@
 name: CI - Dialect Tests
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: true
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-dialect
   cancel-in-progress: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,16 +88,18 @@ jobs:
           flags: schemahcl
       - name: Upload sql test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: sql/junit.xml
+          report_type: test_results
       - name: Upload schemahcl test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: schemahcl/junit.xml
+          report_type: test_results
 
   cli:
     runs-on: ubuntu-latest
@@ -119,10 +121,11 @@ jobs:
           flags: cli
       - name: Upload cli test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: cmd/atlas/junit.xml
+          report_type: test_results
 
   integration:
     runs-on: ubuntu-latest
@@ -144,10 +147,11 @@ jobs:
           flags: integration
       - name: Upload integration test results
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: internal/integration/hclsqlspec/junit.xml
+          report_type: test_results
 
   dialect-integration:
     needs: [lint, generate-cmp, unit, integration]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,3 +156,5 @@ jobs:
   dialect-integration:
     needs: [lint, generate-cmp, unit, integration]
     uses: ./.github/workflows/ci-dialect.yaml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The 17 dialect integration jobs exercise the bulk of atlas's CLI code paths (drivers, schema diffing, migration planning) but were uploading only JUnit test results. That left cmd/atlas showing 10.51% coverage on codecov because the dialect tests never contributed to its coverage report.

Build the atlas binary in build-atlas with -cover -coverpkg=ariga.io/atlas/... so the instrumented binary emits counter files at runtime. Each integration job now creates GOCOVERDIR before running tests, converts the counter files with `go tool covdata textfmt`, and uploads the resulting profile under a per-dialect flag (integration-mysql57, integration-postgres16, etc.).

While touching the codecov steps, migrate all test-results uploads from the deprecated codecov/test-results-action@v1 to codecov/codecov-action@v5 with report_type: test_results. Applied to ci-dialect.yaml (17 jobs) and ci.yaml (sql, schemahcl, cli, integration) for consistency.