### PR TITLE
Add sdk unit test job covering atlasexec and sdk packages, fix tests.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,6 +127,55 @@ jobs:
           files: cmd/atlas/junit.xml
           report_type: test_results
 
+  sdk:
+    runs-on: ubuntu-latest
+    env:
+      GOCOVERDIR: /tmp/gocover
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: cmd/atlas/go.mod
+      - name: Install atlas binary with coverage instrumentation
+        working-directory: cmd/atlas
+        run: go install -cover -coverpkg=ariga.io/atlas/... .
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+      # Tests run twice: -coverprofile internally hijacks GOCOVERDIR so atlas
+      # subprocess counters get nuked. First pass collects harness coverage
+      # and JUnit; second pass (no -coverprofile) collects binary coverage.
+      - name: Run sdk tests (harness coverage + JUnit)
+        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -coverprofile=coverage.txt ./atlasexec/... ./sdk/...
+      - name: Run sdk tests (binary coverage)
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        run: |
+          mkdir -p "$GOCOVERDIR"
+          go test ./atlasexec/... ./sdk/...
+      - name: Convert binary coverage
+        if: ${{ !cancelled() }}
+        run: go tool covdata textfmt -i="$GOCOVERDIR" -o=bincoverage.txt
+      - name: Upload sdk coverage
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.txt
+          flags: sdk
+      - name: Upload sdk binary coverage
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: bincoverage.txt
+          flags: sdk-binary
+      - name: Upload sdk test results
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: junit.xml
+          report_type: test_results
+
   integration:
     runs-on: ubuntu-latest
     steps:

--- a/atlasexec/atlas_migrate_test.go
+++ b/atlasexec/atlas_migrate_test.go
@@ -618,7 +618,10 @@ func TestAtlasMigrate_Apply(t *testing.T) {
 	require.EqualValues(t, "20230926085734", got.Target)
 }
 
+// Skipped: exercises a cloud feature (Atlas Cloud sync / remote dirs)
+// not yet supported by this version of the community edition.
 func TestAtlasMigrate_ApplyWithRemote(t *testing.T) {
+	t.Skip("cloud feature not supported in community edition")
 	type (
 		ContextInput struct {
 			TriggerType    string `json:"triggerType,omitempty"`
@@ -700,6 +703,7 @@ func TestAtlasMigrate_ApplyWithRemote(t *testing.T) {
 }
 
 func TestAtlasMigrate_Push(t *testing.T) {
+	t.Skip("cloud feature not supported in community edition")
 	type (
 		graphQLQuery struct {
 			Query     string          `json:"query"`
@@ -845,6 +849,7 @@ func TestMigrateHash(t *testing.T) {
 }
 
 func TestMigrateRebase(t *testing.T) {
+	t.Skip("cloud feature not supported in community edition")
 	td := t.TempDir()
 	require.NoError(t, os.Mkdir(fmt.Sprintf("%s/migrations", td), 0777))
 	// create initial migrations dir state
@@ -1155,6 +1160,7 @@ func TestAtlasMigrate_LintWithLogin(t *testing.T) {
 }
 
 func TestMigrate_Diff(t *testing.T) {
+	t.Skip("cloud feature not supported in community edition")
 	c, err := atlasexec.NewClient(".", "atlas")
 	require.NoError(t, err)
 	td := t.TempDir()

--- a/atlasexec/atlas_migrate_test.go
+++ b/atlasexec/atlas_migrate_test.go
@@ -479,18 +479,18 @@ func TestAtlasMigrate_ApplyBroken(t *testing.T) {
 		URL:    "sqlite://?mode=memory",
 		DirURL: "file://testdata/broken",
 	})
-	require.ErrorContains(t, err, `sql/migrate: executing statement "broken;" from version "20231029112426": near "broken": syntax error`)
+	require.ErrorContains(t, err, `sql/migrate: executing statement "broken;" from version "20231029112426": SQL logic error: near "broken": syntax error (1)`)
 	require.Nil(t, got)
 	report, ok := err.(*atlasexec.MigrateApplyError)
 	require.True(t, ok)
 	require.Equal(t, "20231029112426", report.Result[0].Target)
-	require.Equal(t, "sql/migrate: executing statement \"broken;\" from version \"20231029112426\": near \"broken\": syntax error", report.Error())
+	require.Equal(t, "sql/migrate: executing statement \"broken;\" from version \"20231029112426\": SQL logic error: near \"broken\": syntax error (1)", report.Error())
 	require.Len(t, report.Result[0].Applied, 1)
 	require.Equal(t, &struct {
 		Stmt, Text string
 	}{
 		Stmt: "broken;",
-		Text: "near \"broken\": syntax error",
+		Text: "SQL logic error: near \"broken\": syntax error (1)",
 	}, report.Result[0].Applied[0].Error)
 }
 

--- a/atlasexec/atlas_migrate_test.go
+++ b/atlasexec/atlas_migrate_test.go
@@ -940,11 +940,6 @@ func TestAtlasMigrate_Lint(t *testing.T) {
 					Code: "DS102",
 					SuggestedFixes: []sqlcheck.SuggestedFix{{
 						Message: "Add a pre-migration check to ensure table \"t2\" is empty before dropping it",
-						TextEdit: &sqlcheck.TextEdit{
-							Line:    1,
-							End:     1,
-							NewText: "-- atlas:txtar\n\n-- checks/destructive.sql --\n-- atlas:assert DS102\nSELECT NOT EXISTS (SELECT 1 FROM `t2`) AS `is_empty`;\n\n-- migration.sql --\nDROP TABLE t2;",
-						},
 					}},
 				}},
 			}},
@@ -967,21 +962,22 @@ func TestAtlasMigrate_Lint(t *testing.T) {
 		require.NoError(t, json.NewDecoder(&buf).Decode(&raw))
 		require.Contains(t, string(raw), "destructive changes detected")
 	})
-	t.Run("lint uses --base and --latest", func(t *testing.T) {
+	t.Run("lint uses --git-base and --latest", func(t *testing.T) {
 		c, err := atlasexec.NewClient(".", "atlas")
 		require.NoError(t, err)
 		summary, err := c.MigrateLint(context.Background(), &atlasexec.MigrateLintParams{
-			DevURL: "sqlite://file?mode=memory",
-			DirURL: "file://testdata/migrations",
-			Latest: 1,
-			Base:   "atlas://test-dir",
+			DevURL:  "sqlite://file?mode=memory",
+			DirURL:  "file://testdata/migrations",
+			Latest:  1,
+			GitBase: "main",
 		})
-		require.ErrorContains(t, err, "--latest, --git-base, and --base are mutually exclusive")
+		require.ErrorContains(t, err, "--latest and --git-base are mutually exclusive")
 		require.Nil(t, summary)
 	})
 }
 
 func TestAtlasMigrate_LintWithLogin(t *testing.T) {
+	t.Skip("cloud feature not supported in community edition")
 	type (
 		migrateLintReport struct {
 			Context *atlasexec.RunContext `json:"context"`

--- a/atlasexec/atlas_schema_test.go
+++ b/atlasexec/atlas_schema_test.go
@@ -871,6 +871,7 @@ func TestSchemaApplyError_Error(t *testing.T) {
 }
 
 func TestAtlasSchema_Lint(t *testing.T) {
+	t.Skip("cloud feature not supported in community edition")
 	t.Run("with broken config", func(t *testing.T) {
 		c, err := atlasexec.NewClient(".", "atlas")
 		require.NoError(t, err)


### PR DESCRIPTION
Ports an old job into new test setup, also removes / skips a bunch of tests that do not work because they either depend on the atlas pro binary, or because they test private code (??????) that does not exist in the repo, or because they are features unsupported in this version for now. 

Fixes several tests otherwise.