### PR TITLE
Add codecov config.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 30%
+
+flag_management:
+  default_rules:
+    carryforward: false


### PR DESCRIPTION
Adds codecov config so that codecov stops reporting a status failure.

Shocked at how low the coverage is lol, wondering if it's a bug or if Atlas team just has private tests they use instead of putting them in the open. Given there's a lot of stuff testing private impls in the public impl I'm guessing that's the case.