### PR TITLE
Fix coverage for integration tests job.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -187,7 +187,7 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
       - name: Run integration tests for HCL
         working-directory: internal/integration/hclsqlspec
-        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -coverprofile=coverage.txt ./...
+        run: gotestsum --junitfile junit.xml --raw-command -- go test -json -race -count=2 -v -coverpkg=ariga.io/atlas/... -coverprofile=coverage.txt ./...
       - name: Upload integration coverage
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
Integration tests job wasn't showing any coverage to upload because go wasn't including that dir by default. So update it to include that dir.